### PR TITLE
feat: 라이브 목록 조회 & 즐겨찾기 한 라이브 목록 조회

### DIFF
--- a/src/components/header/MainHeader.vue
+++ b/src/components/header/MainHeader.vue
@@ -5,7 +5,7 @@
                 <!-- Left-aligned buttons -->
                 <v-col class="d-flex justify-start">
                     <v-btn style="text-transform: none;" @click="this.$router.push(`/farm`)">Farm</v-btn>
-                    <v-btn style="text-transform: none;">Live</v-btn>
+                    <v-btn :to="{ path: '/live/list'}" style="text-transform: none;">Live</v-btn>
                     <v-btn :to="{ path: '/member/my-page' }" style="text-transform: none;" v-if="!isSeller">Mypage</v-btn>
                     <v-btn style="text-transform: none;" v-if="isSeller">MyFarm</v-btn>
                 </v-col>

--- a/src/components/sidebar/SellerSidebar.vue
+++ b/src/components/sidebar/SellerSidebar.vue
@@ -7,7 +7,7 @@
                 </v-list-item>
                 <v-col class="text-center">
                     <v-btn class="cat_btn" :to="{path:'/seller/delivery-management'}">주문 및 배송 관리</v-btn><br>
-                    <v-btn class="cat_btn">매출 내역 관리</v-btn><br>
+                    <v-btn class="cat_btn" :to="{path:'/seller/sales-detail'}">매출 내역 관리</v-btn><br>
                     <v-btn class="cat_btn">상품 관리</v-btn><br>
                     <v-btn class="cat_btn">커뮤니티 관리</v-btn><br>
                     <v-btn class="cat_btn">리뷰 관리</v-btn><br>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import { farmNoticeRouter } from "./farmNoticeRouter";
 import { sellerRouter } from '@/router/sellerRouter';
 import { memberRouter } from "./memberRouter";
 import { farmRouter } from "./farmRouter";
+import { liveRouter } from "./liveRouter";
 
 
 const routes = [
@@ -26,7 +27,8 @@ const routes = [
   ...farmNoticeRouter,
   ...sellerRouter,
   ...memberRouter,
-  ...farmRouter
+  ...farmRouter,
+  ...liveRouter,
 ];
 
 const router = createRouter({

--- a/src/router/liveRouter.js
+++ b/src/router/liveRouter.js
@@ -1,0 +1,10 @@
+import LiveList from '@/views/live/live/LiveList.vue'
+
+export const liveRouter = [
+
+    {
+        path: '/live/list',
+        name: 'LiveList',
+        component: LiveList
+    },
+]

--- a/src/views/live/live/LiveList.vue
+++ b/src/views/live/live/LiveList.vue
@@ -55,8 +55,8 @@
                         <!-- <v-card-text style="text-align: center;"><span style="border-bottom: 2px solid #D4D4D4;"><strong>{{ live.farmName }}</strong></span></v-card-text> -->
                         <v-img
                         class="farm-image"
-                        width="200px"
-                        height="300px"
+                        width="180px"
+                        height="280px"
                         :src="live.liveImage"
                             alt="Farm 썸네일" cover />
                         <v-card-text>

--- a/src/views/live/live/LiveList.vue
+++ b/src/views/live/live/LiveList.vue
@@ -1,0 +1,141 @@
+<template>
+    <v-container>
+        <!-- 즐겨찾기 농장 중 진행중인 라이브 : seller에게는 나타나지 않음 -->
+        <v-card style="border-radius: 15px; padding: 20px; max-width: 1200px; width: 100%; border-bottom: 1px solid #D4D4D4;" 
+        rounded="0" flat v-if="!isSeller">
+            <v-card-title>✨ Favorites</v-card-title>
+            <v-card-text style="color: gray;">스크랩 된 농장의 라이브 목록입니다.</v-card-text>
+            <div style="display: flex; justify-content: center; align-items:center;">
+                <v-btn icon="mdi-chevron-left" variant="plain" @click="prev"></v-btn>
+                <v-window v-model="onboarding" style="width: 1080px;">
+                    <v-window-item v-for="n in windowCount" :key="`window-${n}`" :value="n">
+                        <v-row class="d-flex justify-center">
+                        <v-col v-for="live in paginatedLives(n)" :key="live.id" cols="12" md="3" class="d-flex justify-center">
+                            <v-card variant="text" style="width:235px; height:360px;">
+                            <!-- <v-card-text style="text-align: center;"><span style="border-bottom: 2px solid #D4D4D4;"><strong>{{ live.farmName }}</strong></span></v-card-text> -->
+                            <v-img
+                                class="live-image"
+                                width="235"
+                                height="300px"
+                                :src="live.liveImage"
+                                alt="Farm 썸네일"
+                                cover
+                            />
+                            <v-card-text style="text-align: center;">
+                                <span v-if="live.title.length > 10">[ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}...</span>
+                                <span v-else>[ {{ live.farmName }} ] {{ live.title }}</span>
+                            </v-card-text>
+                            </v-card>
+                        </v-col>
+                        </v-row>
+                    </v-window-item>
+                </v-window>
+                <v-btn icon="mdi-chevron-right" variant="plain" @click="next"></v-btn>
+
+            </div>
+            <!-- <br> -->
+            <v-card-actions style="justify-content: center;">
+                <v-item-group v-model="onboarding" class="text-center" mandatory>
+                    <v-item v-for="n in windowCount" :key="`btn-${n}`" v-slot="{ isSelected, toggle }" :value="n">
+                        <v-btn :color="isSelected ? 'yellow' : 'deep_green'" icon="mdi-circle-small"
+                            @click="toggle"></v-btn>
+                    </v-item>
+                </v-item-group>
+            </v-card-actions>
+        </v-card>
+        
+        <!-- 진행 중인 라이브 목록 -->
+        <v-container style="width: 100%; text-align: center;">
+            <h3>라이브 목록</h3>
+            <v-btn v-if="isSeller" class="start-btn">라이브 시작</v-btn>
+
+            <v-container class="d-flex custom-card-container">
+                <v-row style="justify-content: center;">
+                    <v-card v-for="live in liveList" :key="live.id" class="farm-card" md="2" variant="text" style="width:200px; height:360; margin: 10px; margin-bottom: 15px;">
+                        <!-- <v-card-text style="text-align: center;"><span style="border-bottom: 2px solid #D4D4D4;"><strong>{{ live.farmName }}</strong></span></v-card-text> -->
+                        <v-img
+                        class="farm-image"
+                        width="200px"
+                        height="300px"
+                        :src="live.liveImage"
+                            alt="Farm 썸네일" cover />
+                        <v-card-text>
+                            <span v-if="live.title.length > 10">[ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}... </span>
+                            <span v-else>[ {{ live.farmName }} ] {{live.title}}</span>
+                        </v-card-text>
+                    </v-card>
+                </v-row>
+            </v-container>
+        </v-container>
+
+    </v-container>
+</template>
+
+<script>
+import axios from 'axios';
+export default {
+    data() {
+        return {
+            isSeller: false,
+            favoritesLiveList: [], 
+            onboarding: 1,
+            windowCount: 3,
+            liveList: [],
+        };
+    },
+    async created() {
+        // 즐찾 뿌리기
+        const role = localStorage.getItem('role');
+        if (role === 'SELLER') {
+            this.isSeller = true;
+        } else {
+            this.isSeller = false;
+            
+            try {
+                const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/member-service/favorites/farm/live/list`, {
+                    headers: {
+                        myId: localStorage.getItem('memberId')
+                    }
+                });
+
+                this.favoritesLiveList = response.data;
+                this.windowCount = Math.ceil(this.favoritesLiveList.length / 4);
+            } catch (e) {
+                console.log(e.message);
+            }
+        }
+
+        // 라이브 목록 뿌리기 
+        try {
+            const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/live/active`);
+            this.liveList = response.data;
+        } catch(e) {
+            console.log(e);
+        }
+    },
+    methods: {
+        paginatedLives(page) {
+            const livePerPage = 4; 
+            const start = (page - 1) * livePerPage;
+            const end = start + livePerPage;
+            return this.favoritesLiveList.slice(start, end); 
+        },
+        next() {
+            this.onboarding = this.onboarding + 1 > this.windowCount ? 1 : this.onboarding + 1;
+        },
+        prev() {
+            this.onboarding = this.onboarding - 1 <= 0 ? this.windowCount : this.onboarding - 1;
+        },
+    }
+}
+</script>
+
+<style scoped>
+.start-btn {
+    background-color: #BCC07B; 
+    border-radius: 50px;
+    float: right;
+    margin-right: 30px;
+    font-weight: 700;
+}
+</style>


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [ ] 설정 변경


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 라이브 목록 조회 & 즐겨찾기 한 라이브 목록 조회


## 📷 결과 화면
<!-- 화면을 캡처해주세요 -->
- member가 보는 화면 
![image (61)](https://github.com/user-attachments/assets/5bae35ef-d1c1-4e84-b0d3-4d9cc84c85c8)
![image (62)](https://github.com/user-attachments/assets/8ab72e67-f6bb-4c24-87f6-96e859ef394e)
본인이 스크랩 한 농장의 진행 중인 라이브 목록을 조회할 수 있음 
<br><br>

- 진행 중인 '전체' 라이브 목록 조회 
![image](https://github.com/user-attachments/assets/47360dbc-3180-4884-8299-c028152a7d21)
스크롤링과 페이징 처리 둘 다 시도해봤는데 잘 안돼서 나중에 수정 .. 
<br><br>

- seller가 보는 화면 
![image](https://github.com/user-attachments/assets/5e42aeb8-68ea-40ed-816f-eb27d1714c62)
농장 스크랩을 안하기 때문에 즐겨찾기 한 농장의 라이브 목록 조회는 없음 + 라이브 시작하는 버튼 추가 


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  closed #이슈변호  -->
closed #50 