### PR TITLE
chore: 라이브 목록 및 세션 관련 이슈 해결 

### DIFF
--- a/src/components/menubar/FarmMenuComponent.vue
+++ b/src/components/menubar/FarmMenuComponent.vue
@@ -1,8 +1,8 @@
 <template>
     <v-container style="max-width: 950px;">
         <!-- Header Text -->
-        <v-row justify="center" style="margin-bottom: 10px;">
-            <h2>{{this.farmName}}</h2>
+        <v-row justify="center" style="margin-top: 10px; margin-bottom: 10px;">
+            <h3>{{this.farmName}}</h3>
         </v-row>
 
         <!-- Image Banner -->
@@ -79,14 +79,19 @@ export default {
 }
 .nav-link:hover {
     opacity: 1;
-    transition: 0.3s ease; }
+    /* transition: 0.3s ease;  */
+    background-color: #e0e0e0;
+    padding: 5px;
+    border-radius: 10px;
+}
 
 .menubar {
-    border-top: 1px solid black;
-    border-bottom: 1px solid black;
-    margin-bottom: 30px;
+    border-top: 1.7px solid #b3b3b3;
+    border-bottom: 1.7px solid #b3b3b3;
+    margin-bottom: 10px;
     margin-top: 30px;
     height: 40px;
+    font-size: 14px;
 }
 
 

--- a/src/router/liveRouter.js
+++ b/src/router/liveRouter.js
@@ -1,5 +1,5 @@
 import LiveList from '@/views/live/live/LiveList.vue'
-// import LiveStream from '@/views/live/live/LiveStream.vue';
+import LiveSession from '@/views/live/live/LiveSession.vue'
 
 export const liveRouter = [
 
@@ -8,9 +8,9 @@ export const liveRouter = [
         name: 'LiveList',
         component: LiveList
     },
-    // {
-    //     path: '/live/stream/:sessionId',
-    //     name: 'LiveStream',
-    //     component: LiveStream,
-    //   }
+    {
+        path: '/live/:sessionId', //⭐
+        name: 'LiveSession',
+        component: LiveSession,
+      },
 ]

--- a/src/views/live/live/LiveList.vue
+++ b/src/views/live/live/LiveList.vue
@@ -1,135 +1,128 @@
-<template>
+<template>     
     <v-container>
-        <!-- 🔖 LIVE LIST 화면 -->
-        <template v-if="!session">
-            <!-- 즐겨찾기 농장 중 진행중인 라이브 : seller에게는 나타나지 않음 -->
-            <v-card style="border-radius: 15px; padding: 20px; max-width: 1200px; width: 100%; border-bottom: 1px solid #D4D4D4;" 
-            rounded="0" flat v-if="!isSeller">
-                <v-card-title>✨ Favorites</v-card-title>
-                <v-card-text style="color: gray;">스크랩 된 농장의 라이브 목록입니다.</v-card-text>
-                <div style="display: flex; justify-content: center; align-items:center;">
-                    <v-btn icon="mdi-chevron-left" variant="plain" @click="prev"></v-btn>
-                    <v-window v-model="onboarding" style="width: 1080px;">
-                        <v-window-item v-for="n in windowCount" :key="`window-${n}`" :value="n">
-                            <v-row class="d-flex justify-center">
-                            <v-col v-for="live in paginatedLives(n)" :key="live.id" cols="12" md="3" class="d-flex justify-center">
-                                <v-card variant="text" style="width:235px; height:360px;" @click="joinExistingSession(live.id)">                
-                                <v-img
-                                    class="live-image"
-                                    width="235"
-                                    height="300px"
-                                    :src="live.liveImage"
-                                    alt="Live 썸네일"
-                                    cover
-                                />
-                                <v-card-text style="text-align: center;">
-                                    <span v-if="live.title.length > 10">[ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}...</span>
-                                    <span v-else>[ {{ live.farmName }} ] {{ live.title }}</span>
-                                </v-card-text>
-                                </v-card>
-                            </v-col>
-                            </v-row>
-                        </v-window-item>
-                    </v-window>
-                    <v-btn icon="mdi-chevron-right" variant="plain" @click="next"></v-btn>
-
-                </div>
-                <v-card-actions style="justify-content: center;">
-                    <v-item-group v-model="onboarding" class="text-center" mandatory>
-                        <v-item v-for="n in windowCount" :key="`btn-${n}`" v-slot="{ isSelected, toggle }" :value="n">
-                            <v-btn :color="isSelected ? 'yellow' : 'deep_green'" icon="mdi-circle-small"
-                                @click="toggle"></v-btn>
-                        </v-item>
-                    </v-item-group>
-                </v-card-actions>
-            </v-card>
-            
-            <!-- 진행 중인 라이브 목록 (전체) -->
-            <v-container style="width: 100%; text-align: center;">
-                <h3>라이브 목록</h3>
-                <v-btn v-if="isSeller" class="start-btn" @click="openModal">라이브 시작</v-btn>
-
-                <v-container class="d-flex custom-card-container">
-                    <v-row style="justify-content: center;">
-                        <v-card v-for="live in liveList" :key="live.liveId" class="farm-card" md="2" variant="text" style="width:200px; height:360; margin: 10px; margin-bottom: 15px;"
-                        @click="joinExistingSession(live.liveId)">
-                            <v-img
-                            class="live-image"
-                            width="180px"
-                            height="280px"
-                            :src="live.liveImage"
-                                alt="live 썸네일" cover />
-                            <v-card-text>
-                                <span v-if="live.title.length > 10">[ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}... </span>
-                                <span v-else>[ {{ live.farmName }} ] {{live.title}}</span>
-                            </v-card-text>
-                        </v-card>
-                    </v-row>
-                </v-container>
-            </v-container>
-
-            <!-- 라이브 시작 모달창 : seller가 title과 썸네일 사진을 추가함 -->
-            <v-dialog v-model="startLiveDialog" max-width="600px">
-                <v-card class="live-modal">
-                    <v-card-text style="display: flex; align-items: center; justify-content: center">
-                        <img src="/live.png" width=40 alt="Logo" style="padding-bottom:2px;"/>
-                        <strong>라이브 시작하기</strong>
-                    </v-card-text>
-                    <v-text-field
-                            v-model="title"
-                            placeholder="라이브 제목을 작성하세요."
-                            hide-details
-                            solo-inverted
-                            flat
-                            class="live-input"
-                            prepend-inner-icon="mdi-emoticon-happy-outline"
-                        ></v-text-field>
-                        <v-file-input
-                            label="썸네일 이미지를 추가하세요."
-                            
-                            accept="image/*"
-                            @change="onThumbnailImageUpload"
-                        />
-                        <v-row class="modal-action">
-                            <v-btn class="modal-btn" @click="startLive" style="background-color: #BCC07B;">시작</v-btn>
-                            <v-btn class="modal-btn" @click="cancelLive" style="background-color: #e0e0e0;">취소</v-btn>
-                        </v-row>
-                </v-card>            
-            </v-dialog>
-        </template>
-
-        <!-- 🔖 라이브 세션 화면 : 라이브가 실행되고 비디오가 출력되는 화면면 -->
-        <template v-else>
-            <div>
-                <div id="session-header" style="display: flex; flex-direction: column; align-items: center;">
-                    <h3 style="text-align: center;">{{ title }}</h3>
-                    <div style="width: 100%; display: flex; justify-content: flex-end; margin-top: 10px;">
-                        <v-btn class="live-btn" v-if="isPublisher" @click="leaveSession">라이브 종료</v-btn>
-                        <v-btn class="live-btn" v-if="!isPublisher" @click="leaveSession">나가기</v-btn>
-                    </div>
-                </div>
-                <div id="main-video" class="col-md-6" v-if="isPublisher">
-                    <user-video :stream-manager="mainStreamManager" />
-                </div>
-                <div id="video-container" class="col-md-6" v-if="!isPublisher">
-                    <user-video :stream-manager="publisher" @click="updateMainVideoStreamManager(publisher)" />
-                    <user-video v-for="sub in subscribers" :key="sub.stream.connection.connectionId" :stream-manager="sub"
-                    @click="updateMainVideoStreamManager(sub)" />
-                </div>
-            </div>
-        </template>
+      <!-- 🔖 LIVE LIST 화면 -->
+      <template v-if="!session">   
+        <!-- 즐겨찾기 농장 중 진행중인 라이브 : seller에게는 나타나지 않음 -->
+        <v-card 
+          style="border-radius: 15px; padding: 20px; max-width: 1200px; width: 100%; border-bottom: 1px solid #D4D4D4;" 
+          rounded="0" 
+          flat 
+          v-if="!isSeller">
+          <v-card-title>✨ Favorites</v-card-title>
+          <v-card-text style="color: gray;">스크랩 된 농장의 라이브 목록입니다.</v-card-text>
+          <div style="display: flex; justify-content: center; align-items:center;">
+            <v-btn icon="mdi-chevron-left" variant="plain" @click="prev"></v-btn>
+            <v-window v-model="onboarding" style="width: 1080px;">
+              <v-window-item v-for="n in windowCount" :key="`window-${n}`" :value="n">
+                <v-row class="d-flex justify-center">
+                  <v-col 
+                    v-for="live in paginatedLives(n)" 
+                    :key="live.id" 
+                    cols="12" 
+                    md="3" 
+                    class="d-flex justify-center">
+                    <v-card variant="text" style="width:235px; height:360px;" @click="joinExistingSession(live.id)">
+                      <v-img
+                        class="live-image"
+                        width="235"
+                        height="300px"
+                        :src="live.liveImage"
+                        alt="Live 썸네일"
+                        cover
+                      />
+                      <v-card-text style="text-align: center;">
+                        <span v-if="live.title.length > 10">
+                          [ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}...
+                        </span>
+                        <span v-else>[ {{ live.farmName }} ] {{ live.title }}</span>
+                      </v-card-text>
+                    </v-card>
+                  </v-col>
+                </v-row>
+              </v-window-item>
+            </v-window>
+            <v-btn icon="mdi-chevron-right" variant="plain" @click="next"></v-btn>
+          </div>
+          <v-card-actions style="justify-content: center;">
+            <v-item-group v-model="onboarding" class="text-center" mandatory>
+              <v-item 
+                v-for="n in windowCount" 
+                :key="`btn-${n}`" 
+                v-slot="{ isSelected, toggle }" 
+                :value="n">
+                <v-btn :color="isSelected ? 'yellow' : 'deep_green'" icon="mdi-circle-small" @click="toggle"></v-btn>
+              </v-item>
+            </v-item-group>
+          </v-card-actions>
+        </v-card>
+    
+        <!-- 진행 중인 라이브 목록 (전체) -->
+        <v-container style="width: 100%; text-align: center;">
+          <h3>라이브 목록</h3>
+          <v-btn v-if="isSeller" class="start-btn" @click="openModal">라이브 시작</v-btn>
+          <v-container class="d-flex custom-card-container">
+            <v-row style="justify-content: center;">
+              <v-card 
+                v-for="live in liveList" 
+                :key="live.liveId" 
+                class="live-card" 
+                md="2" 
+                variant="text" 
+                style="width:200px; height:360; margin: 10px; margin-bottom: 15px;" 
+                @click="joinExistingSession(live.liveId)">
+                <v-img
+                  class="live-image"
+                  width="180px"
+                  height="280px"
+                  :src="live.liveImage"
+                  alt="live 썸네일" 
+                  cover
+                />
+                <v-card-text>
+                  <span v-if="live.title.length > 10">
+                    [ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}... 
+                  </span>
+                  <span v-else>[ {{ live.farmName }} ] {{ live.title }}</span>
+                </v-card-text>
+              </v-card>
+            </v-row>
+          </v-container>
+        </v-container>
+    
+        <!-- 라이브 시작 모달창 : seller가 title과 썸네일 사진을 추가함 -->
+        <v-dialog v-model="startLiveDialog" max-width="600px">
+          <v-card class="live-modal">
+            <v-card-text style="display: flex; align-items: center; justify-content: center">
+              <img src="/live.png" width=40 alt="Logo" style="padding-bottom:2px;" />
+              <strong>라이브 시작하기</strong>
+            </v-card-text>
+            <v-text-field
+              v-model="title"
+              placeholder="라이브 제목을 작성하세요."
+              hide-details
+              solo-inverted
+              flat
+              class="live-input"
+              prepend-inner-icon="mdi-emoticon-happy-outline"
+            ></v-text-field>
+            <v-file-input
+              label="썸네일 이미지를 추가하세요."
+              accept="image/*"
+              @change="onThumbnailImageUpload"
+            />
+            <v-row class="modal-action">
+              <v-btn class="modal-btn" @click="startLive" style="background-color: #BCC07B;">시작</v-btn>
+              <v-btn class="modal-btn" @click="cancelLive" style="background-color: #e0e0e0;">취소</v-btn>
+            </v-row>
+          </v-card>
+        </v-dialog>
+      </template>
     </v-container>
 </template>
-
+  
 <script>
 import axios from 'axios';
-import { OpenVidu } from "openvidu-browser";
-import UserVideo from "@/components/video/UserVideo";
-
 export default {
-    components: {
-        UserVideo, // 사용자 비디오 컴포넌트
-    },
     data() {
         return {
             isSeller: false,
@@ -137,19 +130,9 @@ export default {
             onboarding: 1,
             windowCount: 3,
             liveList: [],
-
             startLiveDialog: false,
-            // OpenVidu 관련 객체
-            OV: undefined,
-            session: undefined, // 현재 세션
-            mainStreamManager: undefined, // 메인 화면에 표시할 스트림 관리자
-            publisher: undefined, // 방송자 스트림 관리자
-            subscribers: [], // 구독자들
 
-            mySessionId: '', // 세션 ID
-            myUserName: "Participant" + Math.floor(Math.random() * 100),
-            isPublisher: false, // 방송자 여부
-
+            isPublisher: false, // 방송자 여부 
             title: "",
             liveImage: "",
             file: null,
@@ -166,27 +149,24 @@ export default {
         if (role === 'SELLER') {
             this.isSeller = true;
         } else {
-            this.isSeller = false;
-            
+            this.isSeller = false;     
             try {
-                const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/member-service/favorites/farm/live/list`, {
-                    headers: {
-                        myId: localStorage.getItem('memberId')
-                    }
-                });
-
-                this.favoritesLiveList = response.data;
-                this.windowCount = Math.ceil(this.favoritesLiveList.length / 4);
+            const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/member-service/favorites/farm/live/list`, {
+                headers: {
+                myId: localStorage.getItem('memberId')
+                }
+            });
+            this.favoritesLiveList = response.data;
+            this.windowCount = Math.ceil(this.favoritesLiveList.length / 4);
             } catch (e) {
-                console.log(e.message);
+            console.log(e.message);
             }
         }
-
-        // 전체 라이브 목록 뿌리기 
+        // 전체 라이브 목록 뿌리기
         let params = {
             page: this.currentPage,
             size: this.pageSize,
-        }
+        };
         try {
             const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/live/active`, {params});
             console.log("전체 : ", response.data.content);
@@ -194,7 +174,6 @@ export default {
         } catch(e) {
             console.log(e);
         }
-
         window.addEventListener('scroll', this.scrollPagination);
     },
     methods: {
@@ -214,7 +193,6 @@ export default {
                 headers: headers,
                 body: JSON.stringify(body),
             });
-
             const urlContentType = getUrl.headers.get("content-type");
             let getUrlResult;
             if (urlContentType && urlContentType.includes("application/json")) {
@@ -222,34 +200,30 @@ export default {
             } else {
                 getUrlResult = await getUrl.text(); // 텍스트로 파싱
             }
-
             const awsUrl = {
                 data: `${getUrlResult.split("?")[0]}`,
                 auth: `?${getUrlResult.split("?")[1]}`,
             };
-
-            // 파일을 S3에 업로드
             const options = {
                 method: "PUT", // PUT 메서드 사용
                 headers: {
-                "Content-Type": blob.type, // Blob의 MIME 타입 설정
+                    "Content-Type": blob.type, // Blob의 MIME 타입 설정
                 },
                 body: blob, // 업로드할 파일 데이터
             };
             await fetch(awsUrl.data + awsUrl.auth, options);
-
             return awsUrl.data;
         },
         async onThumbnailImageUpload(event) {
             const file = event?.target?.files[0];
             this.liveImage = await this.handleImageUpload(file);
         },
-        // 즐찾 리스트 슬ㄹㅏ이더 
+        // 즐찾 리스트 슬라이더
         paginatedLives(page) {
-            const livePerPage = 4; 
+            const livePerPage = 4;
             const start = (page - 1) * livePerPage;
             const end = start + livePerPage;
-            return this.favoritesLiveList.slice(start, end); 
+            return this.favoritesLiveList.slice(start, end);
         },
         next() {
             this.onboarding = this.onboarding + 1 > this.windowCount ? 1 : this.onboarding + 1;
@@ -257,22 +231,19 @@ export default {
         prev() {
             this.onboarding = this.onboarding - 1 <= 0 ? this.windowCount : this.onboarding - 1;
         },
-        // 스크롤 
+        // 스크롤
         async loadLive() {
             try {
                 if(this.isLoading || this.isLastPage) return;
-
                 this.isLoading = true;
                 this.currentPage++;
                 let params = {
                     page: this.currentPage,
                     size: this.pageSize,
-                }
-
+                };
                 const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/live/active`, { params });
                 const additionalData = response.data.content;
-                this.liveList = [...this.liveList, ...additionalData]; 
-                
+                this.liveList = [...this.liveList, ...additionalData];
                 this.isLastPage = response.data.last; // 라스트 여부
                 this.isLoading = false; // 로딩 끝!
             } catch(e) {
@@ -286,13 +257,12 @@ export default {
                 this.loadLive();
             }
         },
-
-        // 라이브 시작하기 위해 title, 썸네일 추가하는 모달창 
+        // 라이브 시작하기 위해 title, 썸네일 추가하는 모달창
         openModal() {
             this.startLiveDialog = true;
         },
         cancelLive() {
-            this.startLiveDialog = false; 
+            this.startLiveDialog = false;
             this.title = "";
             this.liveImage = "";
         },
@@ -306,109 +276,45 @@ export default {
                 try {
                     const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions`, liveData, {
                         headers: {
-                        'sellerId': localStorage.getItem('sellerId'),
+                            'sellerId': localStorage.getItem('sellerId'),
                         },
                     });
-                    // 세션 ID 받아오기
-                    this.mySessionId = response.data.sessionId;
-                    this.isPublisher = true; // 방송자로 설정
-                    
-                    // 모달창 닫고 초기화 
-                    this.startLiveDialog = false; 
-                    this.title = "";
-                    this.liveImage = "";
-                    this.joinSession(response.data.title); // 방송 시작
+                    console.log("라우팅 하기 직전 : ", response);
+
+                    this.isPublisher = true;
+
+                    // 세션 시작 후 LiveStream.vue로 이동
+                    this.$router.push({
+                        path: `/live/${response.data.sessionId}`,
+                        query: { title: this.title, isPublisher: true }
+                    });
                 } catch (error) {
                     console.error('라이브 시작 오류:', error);
                 }
             }
         },
-
         // 시청자: 기존 세션에 접속
         async joinExistingSession(liveId) {
             console.log("시청자 세션 : ", liveId);
             this.isPublisher = false; // 시청자 설정
-
-            // 시청할 세션 ID 가져오기
             try {
                 const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${liveId}/sessionId`);
                 console.log(response.data.sessionId);
                 this.mySessionId = response.data.sessionId;
-                console.log("join 세션id : ", this.mySessionId)
-                this.joinSession(response.data.title); // 세션에 접속
+                console.log("join 세션id : ", this.mySessionId);
+
+                // 세션 접속 후 LiveStream.vue로 이동
+                this.$router.push({
+                    path: `/live/${response.data.sessionId}`,
+                    query: { title: response.data.title, isPublisher: false }
+                });
             } catch (error) {
                 console.error('세션 ID 가져오기 오류:', error);
             }
         },
-
-        // OpenVidu 세션에 접속
-        async joinSession(title) {
-            this.OV = new OpenVidu(); // 새로운 OpenVidu 객체 생성
-            this.session = this.OV.initSession(); // 세션 초기화
-            this.title = title;
-
-            // 스트림이 생성될 때마다 실행되는 콜백
-            this.session.on("streamCreated", ({ stream }) => {
-                const subscriber = this.session.subscribe(stream);
-                this.subscribers.push(subscriber); // 구독자를 리스트에 추가
-            });
-
-            // 스트림이 종료될 때 실행되는 콜백
-            this.session.on("streamDestroyed", ({ stream }) => {
-                const index = this.subscribers.indexOf(stream.streamManager);
-                if (index >= 0) {
-                this.subscribers.splice(index, 1); // 종료된 스트림을 구독자 리스트에서 제거
-                }
-            });
-
-            // 백엔드에서 토큰을 받아 세션에 연결
-            const token = await this.getToken(this.mySessionId);
-            this.session.connect(token, { clientData: this.myUserName }).then(() => {
-                if (this.isPublisher) {
-                // 방송자일 경우 자신의 비디오와 오디오를 송출
-                const publisher = this.OV.initPublisher(undefined, {
-                    audioSource: undefined, // 기본 마이크
-                    videoSource: undefined, // 기본 웹캠a
-                    publishAudio: true,
-                    publishVideo: true,
-                    resolution: "640x480",
-                    frameRate: 30,
-                });
-
-                this.mainStreamManager = publisher; // 메인 화면에 방송자 스트림 표시
-                this.publisher = publisher; // 방송자 스트림 저장
-                this.session.publish(this.publisher); // 스트림 송출
-                }
-            });
-        },
-
-        // 세션 종료 : 라이브에서 떠나기 
-        async leaveSession() {
-            if (this.session) {
-                if (this.isPublisher) {
-                    await axios.patch(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${this.mySessionId}/leave`); // 서버에 세션 종료 요청
-                    this.session.disconnect();
-                }
-            }
-            this.session = undefined;
-            this.mainStreamManager = undefined;
-            this.publisher = undefined;
-            this.subscribers = [];
-            this.OV = undefined;
-
-            // 목록으로 나가는데 새로고침 
-            window.location.href = '/live/list';
-        },
-
-        // 백엔드에서 토큰 받아오기
-        async getToken(sessionId) {
-            const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${sessionId}/connections`);
-            return response.data; // 서버에서 생성된 토큰 반환
-        },
     }
-}
+  }
 </script>
-
 <style scoped>
 .start-btn {
     background-color: #BCC07B; 
@@ -420,10 +326,6 @@ export default {
 .live-modal {
     height: 350px;
     padding: 15px;
-}
-.live-btn {
-    background-color: #BCC07B; 
-    border-radius: 50px;
 }
 .modal-action {
     display: flex;

--- a/src/views/live/live/LiveSession.vue
+++ b/src/views/live/live/LiveSession.vue
@@ -1,0 +1,131 @@
+<template>
+    <!-- 🔖 라이브 세션 화면 -->
+    <div>
+      <div id="session-header" style="display: flex; flex-direction: column; align-items: center; padding-top: 30px;">
+        <h3 style="text-align: center;">{{ title }}</h3>
+        <div style="width: 100%; display: flex; justify-content: flex-end; margin-top: 10px;">
+          <v-btn class="live-btn" v-if="isPublisher" @click="leaveSession">라이브 종료</v-btn>
+          <v-btn class="live-btn" v-if="!isPublisher" @click="leaveSession">나가기</v-btn>
+        </div>
+      </div>
+      <div id="main-video" class="col-md-6 video-style" v-if="isPublisher">
+        <user-video :stream-manager="mainStreamManager" />
+      </div>
+      <div id="video-container" class="col-md-6 video-style" v-if="!isPublisher">
+        <user-video :stream-manager="publisher" @click="updateMainVideoStreamManager(publisher)" />
+        <user-video 
+          v-for="sub in subscribers" 
+          :key="sub.stream.connection.connectionId" 
+          :stream-manager="sub" 
+          @click="updateMainVideoStreamManager(sub)" />
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  import axios from 'axios';
+  import { OpenVidu } from "openvidu-browser";
+  import UserVideo from "@/components/video/UserVideo"; //⭐
+  export default {
+    components: {
+      UserVideo //⭐
+    },
+    data() {
+      return {
+        session: undefined, 
+        mainStreamManager: undefined,
+        publisher: undefined,
+        subscribers: [],
+        isPublisher: false,
+        title: "", 
+        OV: undefined,
+        mySessionId: "",
+      };
+    },
+    async created() {
+        const { sessionId } = this.$route.params;
+        const title = this.$route.query.title;
+        const isPublisher = this.$route.query.isPublisher === 'true'; // 방송자인지 시청자인지 구분 
+
+        this.title = title;
+        this.isPublisher = isPublisher;
+        this.mySessionId = sessionId;
+        this.joinSession(sessionId);    
+    },
+    methods: {
+        async joinSession(sessionId) {
+            console.log("화면들어옴 sessionId: ", sessionId);
+            this.OV = new OpenVidu();
+            this.session = this.OV.initSession();
+
+            // 스트림 생성 및 제거 처리
+            this.session.on("streamCreated", ({ stream }) => {
+                const subscriber = this.session.subscribe(stream);
+                this.subscribers.push(subscriber);
+            });
+
+            this.session.on("streamDestroyed", ({ stream }) => {
+            const index = this.subscribers.indexOf(stream.streamManager);
+            if (index >= 0) {
+                this.subscribers.splice(index, 1);
+            }
+            });
+            
+            // 백엔드에서 토큰 받아와서 세션에 연결
+            const token = await this.getToken(sessionId);
+            this.session.connect(token, { clientData: this.myUserName }).then(() => {
+                console.log("isPublisher: ", this.isPublisher);
+                if (this.isPublisher) {
+                    // 방송자일 경우 자신의 비디오와 오디오를 송출
+                    const publisher = this.OV.initPublisher(undefined, {
+                        audioSource: undefined, // 기본 마이크
+                        videoSource: undefined, // 기본 웹캠a
+                        publishAudio: true,
+                        publishVideo: true,
+                        resolution: "640x480",
+                        frameRate: 30,
+                    });
+
+                    this.mainStreamManager = publisher; // 메인 화면에 방송자 스트림 표시
+                    this.publisher = publisher; // 방송자 스트림 저장
+                    this.session.publish(this.publisher); // 스트림 송출
+                }
+            });
+        },
+      
+        async getToken(sessionId) {
+            const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${sessionId}/connections`);
+            return response.data;
+        },
+        async leaveSession() {
+            if (this.session) {
+                if (this.isPublisher) {
+                    await axios.patch(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${this.mySessionId}/leave`); // 서버에 세션 종료 요청
+                    // this.session.disconnect();
+                }
+                this.session.disconnect();
+            }
+            this.session = undefined;
+            this.mainStreamManager = undefined;
+            this.publisher = undefined;
+            this.subscribers = [];
+            this.OV = undefined;
+
+            // 목록으로 나가는데 새로고침 
+            window.location.href = '/live/list';
+        },
+    },
+  };
+</script>
+<style scroped>
+.live-btn {
+    background-color: #BCC07B; 
+    border-radius: 50px;
+    margin-right: 8%;
+}
+.video-style {
+    margin-left: 8%;
+}
+</style>
+
+  

--- a/src/views/product/farm/FarmPackageList.vue
+++ b/src/views/product/farm/FarmPackageList.vue
@@ -2,9 +2,9 @@
     <FarmMenuComponent :currentMenu="2"/>
   
     <v-container style="max-width: 1200px;"> <!-- max-width를 1200px로 조정 -->
-      <v-row justify="center" style="margin-bottom: 10px;">
+      <!-- <v-row justify="center" style="margin-bottom: 10px;">
         <h2>패키지 둘러보기</h2>
-      </v-row>
+      </v-row> -->
   
       <!-- 에러 메시지 출력 -->
       <v-row v-if="errorMessage">


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [ ] 설정 변경


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- live list화면과 live session 파일 분리 
- live 목록 스크롤 처리 
- 라이브 시청중 실수로 뒤로가기 버튼 눌렀을 때 발생하는 이슈 해결 (모달창으로 방지) 

## 📷 결과 화면
<!-- 화면을 캡처해주세요 -->
- 라이브 목록 스크롤링 <br> 
![녹음 2024-10-05 194935 (2) (1)](https://github.com/user-attachments/assets/b9ec81fe-7e55-4356-ae7c-ebc3079f8619)
<br><br>

- LiveList.vue와 LiveSession.vue 파일 분리 <br> 

![image (75)](https://github.com/user-attachments/assets/4ce3e9f0-b04b-49ce-9a3b-0a571c97641a)
위 화면은 test2@naver.com seller의 계정

![image (76)](https://github.com/user-attachments/assets/da1fcf84-bf33-43d5-9d75-8b79261d1a50)
위 화면은 test@naver.com seller의 계정

=> 기존에는 파일 분리를  _실패_ 해서 목록부터 라이브 방송까지 하나의 파일로 구현했더니, **모든 라이브의 url이 같아지는 이슈가 발생**했음. 그동안은 문제가 없었지만 일단 url이 무조건 달라야 하는건 기본이라 파일 분리는 필수였고, 또 목록에서 커서를 올렸을 때 영상이 실행되는 것을 시도하려고 찾아보니 무조건 분리를 시켜야 했음 .. 
<br>

![image (77)](https://github.com/user-attachments/assets/132e1e6a-9204-4fe5-a972-636bf3c7d1e0)
아무튼 모든 화면에서 다른 url로 방송과 시청이 잘 됨 ! 
<br><br>

- 뒤로가기 이슈 해결 
![녹음 2024-10-06 010317 (1)](https://github.com/user-attachments/assets/7c8e4620-b172-475c-aab7-d122316bc435)
방송자가 실수로 뒤로가기 버튼을 눌러도 바로 나가져서 isPublisher=true가 되는 문제가 발생하지 않음 ! 무조건 취소 or 종료만 존재 


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  closed #이슈변호  -->
closed #84 