### PR TITLE
feat: seller도 공지사항 > 댓글에 작성/수정/조회/삭제 가능 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,8 +49,10 @@ export default {
  src: url('//fastly.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot');
  src: url('//fastly.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot?#iefix') format('embedded-opentype'), url('//fastly.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.woff') format('woff'), url('//fastly.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.ttf') format('truetype');
 }
+/* 나눔 스퀘어 */
+@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
 .font-style {
-  font-family: 'NanumSquareRound';
+  font-family: 'https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css';
 }
 </style>
 

--- a/src/components/menubar/FarmMenuComponent.vue
+++ b/src/components/menubar/FarmMenuComponent.vue
@@ -1,18 +1,34 @@
 <template>
     <v-container style="max-width: 95%;">
         <!-- Header Text -->
-        <v-row justify="center" style="margin-top: 10px; margin-bottom: 5px;">
+        <!-- <v-row justify="center" style="margin-top: 10px; margin-bottom: 5px;">
             <h4>{{this.farmName}}</h4> &nbsp;&nbsp;
             <div style="text-align: center;">
                 <v-chip class="like-chip" size="small" color="deep_orange">
                     💛 {{ this.favoriteCount }}
                 </v-chip>
             </div>
-        </v-row>
+        </v-row> -->
         <!-- Image Banner -->
         <v-row justify="center">
-            <v-img :src="this.bannerImage" alt="Farm Image" class="banner-image" height="400px" width="100%" contain></v-img>
+            <v-img :src="this.bannerImage" alt="Farm Image" class="banner-image" style="margin-top: 10px; height:400px; width:100%;" contain></v-img>
         </v-row>
+        <!-- 프로필 이미지 및 농장명 -->
+         <v-row>
+            <div id="session-header" style="position: relative;">
+            <v-row class="farm-info">
+              <div class="farm-image-frame">
+                <v-img :src="profileImageUrl" class="farm-image-circle" cover />
+              </div>
+              <div class="farm-text" style="margin-top: -100px; margin-left: 120px; text-align: start;">
+                <span class="farm-name" style="margin-left: 10px;">{{ this.farmName }}</span><br>
+                <span style="font-size: 14px; color: grey; margin-left: 10px;"> 스크랩 수 {{ this.favoriteCount }}</span><br>
+                <span style="font-size: 14px; color: grey; margin-left: 10px;"> {{ this.farmIntro }}</span>
+              </div>
+            </v-row>
+          </div>
+         </v-row>
+
         <v-row justify="center" class="mt-5 menubar" style="line-height: 15px;">
             <v-col cols="3" class="text-center">
                 <span
@@ -70,6 +86,8 @@ export default {
             bannerImage: "",
             farmName: "",
             favoriteCount: "",
+            profileImageUrl: "",
+            farmIntro: "",
         }
     },
     async created() {
@@ -82,6 +100,9 @@ export default {
             this.bannerImage = response.data.bannerImageUrl;
             this.farmName = response.data.farmName;
             this.favoriteCount = response.data.favoriteCount;
+            this.profileImageUrl = response.data.profileImageUrl;
+            this.farmIntro = response.data.farmIntro;
+
             console.log(this.bannerImage);
         } catch(e) {
             console.log(e);
@@ -104,7 +125,7 @@ export default {
 
 .menubar {
   font-family: "Noto Sans JP", sans-serif;
-  margin-top: 30px;
+  /* margin-top: 30px; */
   height: 40px;
   font-size: 14px;
   color: #3b3b3b;
@@ -134,5 +155,29 @@ export default {
   background-color: #488c54;
   transition: left 0.3s ease, width 0.3s ease;
   z-index: 2; 
+}
+.farm-image-circle {
+    border-radius: 200px;
+    width: 200px;
+    height: 200px;
+    border: solid 0.5px #D4D4D4;
+    background-position: center;
+    background-size: cover;
+    transition: background-size 0.5s ease;
+    bottom: 85px;
+    left: 120px; 
+}
+.farm-info {
+  display: flex;
+  align-items: center;
+  margin-bottom: -60px;
+}
+.farm-image-frame {
+  margin-right: 10px;
+}
+.farm-name {
+  margin: 0;
+  font-size: 18px;
+  font-weight: bold;
 }
 </style>

--- a/src/views/product/farmNotice/NoticeDetailWithComment.vue
+++ b/src/views/product/farmNotice/NoticeDetailWithComment.vue
@@ -4,7 +4,7 @@
         <v-row justify="center">
             <v-col cols="12" sm="8" md="6" lg="8">
                 <v-card class="notice-class elevation-0" outlined>
-                    <v-card-title style="font-size: 17px;"> {{ title }} </v-card-title>
+                    <v-card-title style="font-size: 17px; font-weight: bold;"> {{ title }} </v-card-title>
                     <v-card-text>{{ content }}</v-card-text>
 
                     <v-carousel
@@ -41,13 +41,13 @@
                 <!-- 댓글 조회 -->
                 <v-card v-for="comment in commentList" :key="comment.id" class="comment-class elevation-0" outlined>
                     <v-row>
-                        <v-card-text style="font-size: 14px; color: grey;">&nbsp;&nbsp;@{{ comment.name }}&nbsp;
+                        <v-card-text style="font-size: 14px; color: black;">&nbsp;&nbsp;@{{ comment.name }}&nbsp;
                             <span style="font-size: 13px;">({{ comment.formattedDate }})</span></v-card-text>
                         <v-btn v-if="comment.memberId == userId" color="white" style="box-shadow: none; border: none; margin-bottom: 10px; font-size: 12px;" @click="openOptions(comment)">
                             <img src="/plus.png" width=13 alt="Logo" /> 
                         </v-btn>
                     </v-row>
-                    <v-card-text style="font-size: 15px;">{{ comment.contents }}</v-card-text>
+                    <v-card-text style="font-size: 16px;">{{ comment.contents }}</v-card-text>
                     <hr class="hr-style">
                     <br>
 
@@ -236,11 +236,7 @@ export default {
         },
         async deleteComment(commentId) { // 댓글 삭제 
             try {
-                await axios.delete(`${process.env.VUE_APP_API_BASE_URL}/product-service/farm/notice/comment/${commentId}/delete`, {
-                    headers: {
-                        myId: this.userId
-                    }
-                });
+                await axios.delete(`${process.env.VUE_APP_API_BASE_URL}/product-service/farm/notice/comment/${commentId}/delete`);
                 this.farmNoticeDetail(this.currentPage);
                 this.dialog = false;
                 this.alertModal = true;

--- a/src/views/product/farmNotice/NoticeDetailWithComment.vue
+++ b/src/views/product/farmNotice/NoticeDetailWithComment.vue
@@ -19,6 +19,7 @@
                         <v-img :src="image" alt="Notice image" height="300"></v-img>
                         </v-carousel-item>
                     </v-carousel>
+                    <br>
                 </v-card>
                 <br>
                 <h3 style="padding-left: 15px;">댓글 {{ commentCnt }}개</h3>
@@ -40,13 +41,13 @@
                 <!-- 댓글 조회 -->
                 <v-card v-for="comment in commentList" :key="comment.id" class="comment-class elevation-0" outlined>
                     <v-row>
-                        <v-card-text>&nbsp;&nbsp;&nbsp;<strong>@{{ comment.name }}</strong>&nbsp;&nbsp;
-                            <span style="font-size: 12px;">({{ comment.formattedDate }})</span></v-card-text>
+                        <v-card-text style="font-size: 14px; color: grey;">&nbsp;&nbsp;@{{ comment.name }}&nbsp;
+                            <span style="font-size: 13px;">({{ comment.formattedDate }})</span></v-card-text>
                         <v-btn v-if="comment.memberId == userId" color="white" style="box-shadow: none; border: none; margin-bottom: 10px; font-size: 12px;" @click="openOptions(comment)">
                             <img src="/plus.png" width=13 alt="Logo" /> 
                         </v-btn>
                     </v-row>
-                    <v-card-text>{{ comment.contents }}</v-card-text>
+                    <v-card-text style="font-size: 15px;">{{ comment.contents }}</v-card-text>
                     <hr class="hr-style">
                     <br>
 
@@ -151,12 +152,15 @@ export default {
                 const farm_id = this.$route.params.farmId;
                 const notice_id = this.$route.params.notice_id;
                 const memberId = localStorage.getItem('memberId');
+                const sellerId = localStorage.getItem('sellerId');
+
                 const commentData = {
                     contents: this.comment
                 };
                 await axios.post(`${process.env.VUE_APP_API_BASE_URL}/product-service/farm/${farm_id}/notice/${notice_id}/comment/create`, commentData, {
                     headers: {
-                        myId: memberId
+                        myId: memberId,
+                        sellerId: sellerId
                     }
                 });
 
@@ -264,6 +268,7 @@ export default {
 }
 .comment-class {
     padding-left: 12px;
+    margin-top: -5px;
 }
 .comment-input {
     padding-left: 25px;
@@ -278,7 +283,7 @@ export default {
 .hr-style {
   border: none;
   border-top: 0.9px solid lightgray; 
-  margin-top: 10px;
+  margin-top: 3px;
 }
 .modal-btn {
     border: none;

--- a/src/views/product/farmNotice/NoticeDetailWithComment.vue
+++ b/src/views/product/farmNotice/NoticeDetailWithComment.vue
@@ -41,8 +41,14 @@
                 <!-- 댓글 조회 -->
                 <v-card v-for="comment in commentList" :key="comment.id" class="comment-class elevation-0" outlined>
                     <v-row>
-                        <v-card-text style="font-size: 14px; color: black;">&nbsp;&nbsp;@{{ comment.name }}&nbsp;
-                            <span style="font-size: 13px;">({{ comment.formattedDate }})</span></v-card-text>
+                        <v-card-text style="font-size: 14px; color: black;">
+                            <!-- 농장 주인이 본인 글에 댓글 다는 경우 -->
+                            <span v-if="comment.sellerId === ownSeller" style="background-color: #e0e0e0; border-radius: 50px; padding: 5px;">
+                                @{{ comment.name }}
+                            </span>
+                            <!-- 그 외의 고객들이 댓글 다는 경우 -->
+                            <span v-else>&nbsp;@{{ comment.name }}</span>
+                            <span style="font-size: 13px; color: grey;">&nbsp;&nbsp;{{ comment.formattedDate }}</span></v-card-text>
                         <v-btn v-if="comment.memberId == userId" color="white" style="box-shadow: none; border: none; margin-bottom: 10px; font-size: 12px;" @click="openOptions(comment)">
                             <img src="/plus.png" width=13 alt="Logo" /> 
                         </v-btn>
@@ -116,6 +122,7 @@ export default {
             commentCnt: 0,
             commentList: [],
             comment: "",
+            ownSeller: "",
 
             currentPage: 1, // 페이지 1번부터 시작 
             pageSize: 15, // 한 페이지에 15개씩 출력 
@@ -183,6 +190,7 @@ export default {
                 this.content = response.data.content;
                 this.commentCnt = response.data.commentCnt;
                 this.images = response.data.noticeImages;
+                this.ownSeller = response.data.sellerId;
 
                 const response2 = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/product-service/farm/no-auth/${farm_id}/notice/${notice_id}/comment`, {
                     params: {


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [ ] 설정 변경


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
-  seller도 공지사항 > 댓글에 작성/수정/조회/삭제 가능 
- farm detail 페이지 디자인 수정 (프로필 사진 및 한 줄 소개 추가) 
- 댓글에서 농장 주인의 경우 구분 넣기 

## 📷 결과 화면
<!-- 화면을 캡처해주세요 -->
- seller도 댓글 작성하기 
![image (87)](https://github.com/user-attachments/assets/b0309fc9-ede3-46f9-9d66-6b0637334a40)
여기서 테스트2는 농장 주인 = 공지사항 작성한 사람임 <br>
+) 수정 및 삭제도 가능하게 추가했습니다 !! 
<br> ++) 이 위에 사진은 폰트 변경 전에 캡쳐한거라 둥글둥글합니다 .. 
<br><br> 

- 농장 주인이 댓글을 달았을 때 구분해주기 
![image (88)](https://github.com/user-attachments/assets/6eeed36a-5bfb-48e3-92db-c4028c229a8b)
![image (89)](https://github.com/user-attachments/assets/2e5cf433-ef01-4d84-9699-7a6f469fa768)
이거 보고 따라했는데 딱히 유튜브도 그렇게 예쁘게 되어있진 않네요.. ㅎㅎ 
<br><br>

- 농장 디테일 디자인 수정 
![image (90)](https://github.com/user-attachments/assets/b9ccf5fc-5d43-47dc-b3c1-373395c5ecda)
농장의 프로필 이미지와 농장 제목, 스크랩 수, farmIntro를 넣어봤음 <br>

+) 여기서 제안할 사항 ⇒ 기존의 farmIntro를 위 사진에서처럼 ‘한 줄 소개’로 사용하면 어떨까요! 농장 소개 페이지에 들어가는건 어차피 에디터를 활용하기 때문에 따로 관리해도 될 것 같습니다 



## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  closed #이슈변호  -->
closed #143 