### PR TITLE
feat&chore: 목록이 출력되고 라이브 프리뷰 자동 재생되도록 구현 

### DIFF
--- a/src/views/live/live/LiveList.vue
+++ b/src/views/live/live/LiveList.vue
@@ -69,6 +69,19 @@
               <v-btn class="cat-btn" :class="{'active-cat-btn': category === '야채'}" @click="setCategory('야채')">
                 <i class="mdi mdi-mushroom" style="font-size: 15px;"></i>야채
               </v-btn>
+              <v-btn class="cat-btn" :class="{'active-cat-btn': category === '견과/쌀'}" @click="setCategory('견과/쌀')">
+                <i class="mdi mdi-food-croissant" style="font-size: 15px;"></i>견과/쌀
+              </v-btn>
+              <v-btn class="cat-btn" :class="{'active-cat-btn': category === '육류'}" @click="setCategory('육류')">
+                <i class="mdi mdi-food-drumstick" style="font-size: 15px;"></i>육류
+              </v-btn>
+              <v-btn class="cat-btn" :class="{'active-cat-btn': category === '계란'}" @click="setCategory('계란')">
+                <i class="mdi mdi-egg" style="font-size: 15px;"></i>계란
+              </v-btn>
+              <v-btn class="cat-btn" :class="{'active-cat-btn': category === '유제품'}" @click="setCategory('유제품')">
+                <i class="mdi mdi-cup-water" style="font-size: 15px;"></i>유제품
+              </v-btn>
+              
             </v-row>
           </div>
           <br>
@@ -134,7 +147,7 @@
             ></v-text-field>
             <v-select
               v-model="category"
-              :items="['과일', '야채']"
+              :items="['과일', '야채', '견과/쌀', '육류', '계란', '유제품']"
               label="카테고리를 선택하세요"
               hide-details
               solo-inverted

--- a/src/views/live/live/LiveSession.vue
+++ b/src/views/live/live/LiveSession.vue
@@ -382,21 +382,22 @@ export default {
   font-size: 16px;
 }
 .farm-image-circle {
-    border-radius: 200px;
-    width: 70px;
-    height: 70px;
-    border: solid 0.5px #D4D4D4;
-    background-position: center;
-    background-size: cover;
-    transition: background-size 0.5s ease;
-    margin-left: 1%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 .farm-info {
   display: flex;
   align-items: center;
 }
 .farm-image-frame {
-  margin-right: 10px;
+  position: relative;
+  width: 70px;
+  height: 70px;
 }
 .farm-text {
   display: flex;


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [ ] 설정 변경


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 카테고리 종류 추가 
- 목록이 출력되고 라이브 프리뷰 자동 재생되도록 구현 

## 📷 결과 화면
<!-- 화면을 캡처해주세요 -->
- 라이브 목록에 카테고리 종류 추가 
![image](https://github.com/user-attachments/assets/ab099570-13c4-4fda-947c-facfc2ed639a)
<br><br>

- 라이브 프리뷰 자동 재생 
![live13](https://github.com/user-attachments/assets/ebabb0b2-8242-4bc9-8d5a-2195bdebaf55)
<br><br>

- log로 확인 
<img src="https://github.com/user-attachments/assets/319bc458-7d65-48b1-bd25-260c455f64c5" width=600>
<br>
선택된 카테고리에 라이브가 존재할 경우 ⇒ liveId와 시작 로그 출력 <br><br>

<img src="https://github.com/user-attachments/assets/5fc3c7b2-1ba4-4c3c-868b-e059070efcc5" width=600>
<br>
다른 카테고리를 선택하면 기존의 프리뷰 라이브 중지됨 



## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  closed #이슈변호  -->
closed #149 