### PR TITLE
feat: 메인 페이지 > live best5 출력

### DIFF
--- a/src/components/menubar/FarmMenuComponent.vue
+++ b/src/components/menubar/FarmMenuComponent.vue
@@ -11,7 +11,7 @@
               <div class="farm-image-frame">
                 <v-img :src="profileImageUrl" class="farm-image-circle" cover />
               </div>
-              <div class="farm-text" style="margin-top: -90px; margin-left: 110px; text-align: start;">
+              <div class="farm-text" style="margin-top: -40px; margin-left: 170px; text-align: start;">
                 <span class="farm-name" style="margin-left: 10px;">{{ this.farmName }}</span><br>
                 <span style="font-size: 14px; color: grey; margin-left: 10px;"> {{ this.farmIntro }}</span>
               </div>
@@ -19,6 +19,7 @@
           </div>
          </v-row>
 
+         <br><br>
         <v-row justify="center" class="mt-5 menubar" style="line-height: 15px;">
             <v-col cols="3" class="text-center">
                 <span
@@ -140,13 +141,13 @@ export default {
 }
 .farm-image-circle {
     border-radius: 200px;
-    width: 200px;
-    height: 200px;
+    width: 120px;
+    height: 120px;
     border: solid 0.5px #D4D4D4;
     background-position: center;
     background-size: cover;
     transition: background-size 0.5s ease;
-    bottom: 85px;
+    bottom: 50px;
     left: 120px; 
 }
 .farm-info {
@@ -155,11 +156,11 @@ export default {
   margin-bottom: -60px;
 }
 .farm-image-frame {
-  margin-right: 10px;
+  margin-right: -50px;
 }
 .farm-name {
   margin: 0;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: bold;
 }
 

--- a/src/views/live/live/LiveList.vue
+++ b/src/views/live/live/LiveList.vue
@@ -245,10 +245,13 @@ export default {
             this.liveList = response.data.content;
 
             this.liveList.forEach(live => {
-              Object.assign(live, { isPreviewing: false });
+              Object.assign(live, { isPreviewing: false, session: null });
             }); // ispreviewing 필드 live에 추가 
 
             this.filteredLiveList = this.liveList;  // 필터링 목록 초기화  
+            setTimeout(() => {
+              this.playPreviewAll();
+            }, 1000);
         } catch(e) {
             console.log(e);
         }
@@ -444,7 +447,9 @@ export default {
         // 목록 뿌려지자마자 1.5초 뒤에 전체 프리뷰 뿌려짐 
         async playPreviewAll() {
           for (const live of this.filteredLiveList) {
-            this.playPreview(live);
+            if (!live.isPreviewing) {
+              this.playPreview(live);
+            }
           }
         },
         // 커서 올리면 영상 미리볼 수 있는 화면 출력  
@@ -459,6 +464,8 @@ export default {
 
             const OV = new OpenVidu();
             const session = OV.initSession();
+            live.session = session; // 세션을 저장해 해제할 수 있도록 함 
+
             session.on('streamCreated', ({ stream }) => {
               const videoRef = this.$refs['videoPlayer-' + live.liveId];
               const videoElement = videoRef ? videoRef[0] : null;
@@ -489,8 +496,25 @@ export default {
         } catch (error) {
           console.error('Error fetching token for preview:', error);
         }
-      }
-    }
+      },
+      stopAllPreviews() {
+        for (const live of this.filteredLiveList) {
+          if (live.isPreviewing) {
+            live.isPreviewing = false;
+            console.log(">>>>>" + live.liveId + "번째 라이브 중지");
+
+            if (live.session) {
+              live.session.disconnect();
+              live.session = null;
+            }
+          }
+        }
+      },
+    },
+    beforeRouteLeave(to, from, next) {
+      this.stopAllPreviews();
+      next();
+    },
   }
 </script>
 <style scoped>

--- a/src/views/live/live/LiveListBest.vue
+++ b/src/views/live/live/LiveListBest.vue
@@ -1,0 +1,192 @@
+<template>
+    <v-container>
+        <div>
+            <v-container class="d-flex custom-card-container">
+            <v-row class="justify-start">
+              <v-card 
+                v-for="live in liveListBest" 
+                :key="live.liveId" 
+                class="live-card" 
+                md="2" 
+                variant="text" 
+                style="width:200px; height:340px; margin: 10px; margin-bottom: 15px;" 
+                @click="joinExistingSession(live.liveId)">
+                <div v-if="live.participantCount !== null && live.participantCount !== undefined" class="viewer-count">
+                  {{ live.participantCount - 1}}명 시청 중
+                </div>
+                <!-- 프리뷰 라이브 -->
+                <video
+                  v-if="live.isPreviewing"
+                  :ref="'videoPlayer-' + live.liveId"
+                  muted
+                  autoplay
+                  loop
+                  class="live-video-preview"
+                  style="width: 100%; height: 100%; object-fit: cover; border-radius: 15px;"
+                ></video>
+                <!-- 썸네일 -->
+                <v-img
+                  width="100%"
+                  height="280px"
+                  :src="live.liveImage"
+                  alt="live 썸네일" 
+                  cover
+                />
+                <v-card-text>
+                  <span v-if="live.title.length > 10">
+                    [ {{ live.farmName }} ] {{ live.title.substring(0, 10) }}... 
+                  </span>
+                  <span v-else>[ {{ live.farmName }} ] {{ live.title }}</span>
+                </v-card-text>
+              </v-card>
+            </v-row>
+          </v-container>
+        </div>
+    </v-container>
+
+</template>
+
+<script>
+import axios from 'axios';
+import { OpenVidu } from "openvidu-browser";
+export default {
+    props: {
+      autoStart: {
+        type: Boolean,
+        default: false
+      }
+    },
+    data() {
+        return {
+            liveListBest: [],
+        }
+    },
+    created() {
+        this.fetchLiveListBest();
+        if (this.autoStart) {
+          setTimeout(() => {
+            this.playPreviewAll();
+          }, 1000); // 필요한 경우 지연 시간 조정
+        }
+    },
+    methods: {
+        async fetchLiveListBest() {
+            try {
+                const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/live/active/best`);
+                console.log(">>>>response : ", response.data.content);
+
+                this.liveListBest = response.data.content;
+                this.liveListBest.forEach(live => {
+                    Object.assign(live, { isPreviewing: false, session: null});
+                }); // ispreviewing 필드 live에 추가 
+                
+            } catch(e) {
+                console.log(e.message);
+            }
+        },
+        // 시청자: 기존 세션에 접속
+        async joinExistingSession(liveId) {
+            console.log("시청자 세션 : ", liveId);
+            this.isPublisher = false; // 시청자 설정
+            try {
+                const response = await axios.get(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${liveId}/sessionId`);
+                console.log(response.data.sessionId);
+                this.mySessionId = response.data.sessionId;
+                console.log("join 세션id : ", this.mySessionId);
+
+                // 세션 접속 후 LiveStream.vue로 이동
+                this.$router.push({
+                    path: `/live/${response.data.sessionId}`,
+                    query: { title: response.data.title, 
+                             isPublisher: false,
+                             farmName: response.data.farmName,
+                             profileImageUrl: response.data.profileImageUrl }
+                });
+            } catch (error) {
+                console.error('세션 ID 가져오기 오류:', error);
+            }
+        },
+        // 목록 뿌려지자마자 1.5초 뒤에 전체 프리뷰 뿌려짐 
+        async playPreviewAll() {
+          for (const live of this.liveListBest) {
+            if (!live.isPreviewing) {
+              this.playPreview(live);
+            }
+          }
+        },
+        // 모든 프리뷰 중단
+        stopAllPreviews() {
+          for (const live of this.liveListBest) {
+            if (live.isPreviewing) {
+              live.isPreviewing = false;
+              console.log(">>>>>>>>>" + live.liveId + "번 라이브 중단됨");
+
+              if (live.session) {
+                live.session.disconnect();
+                live.session = null;
+              }
+            }
+          }
+        },
+        async playPreview(live) {
+          console.log(">>>>>>>" + live.liveId + "번째 라이브 시작");
+          try {
+            live.isPreviewing = true;
+            await this.$nextTick();
+
+            const token = await this.getToken(live.sessionId);
+            console.log(">>>>>>>>> token: " + token + " >>>>>>>>>> sessiongId" + live.sessionId);
+
+            const OV = new OpenVidu();
+            const session = OV.initSession();
+            session.on('streamCreated', ({ stream }) => {
+              const videoRef = this.$refs['videoPlayer-' + live.liveId];
+              const videoElement = videoRef ? videoRef[0] : null;
+              console.log(">>>>>>>>>video element: ", videoElement)
+
+              if (videoElement) {
+                const subscriber = session.subscribe(stream, undefined);
+                subscriber.addVideoElement(videoElement);
+              } else {
+                console.warn('경고: Video element is not yet available for preview.');
+              }
+            });
+
+            await session.connect(token, { clientData: 'Preview' }).then(() => {
+              console.log("세션 연결됨 > Current connections: ", session.remoteConnections);
+            }).catch(error => {
+              console.error("세션 연결 실패:", error);
+            });
+
+          } catch (error) {
+              console.error('영상 미리보기 오류:', error);
+          }
+      },
+      async getToken(sessionId) {
+        try {
+          const response = await axios.post(`${process.env.VUE_APP_API_BASE_URL}/live-service/api/sessions/${sessionId}/connections`);
+          return response.data;
+        } catch (error) {
+          console.error('Error fetching token for preview:', error);
+        }
+      }
+    },
+    unmounted() {
+      this.stopAllPreviews();
+    }
+}
+</script>
+
+<style scoped>
+.viewer-count {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: rgba(0, 0, 0, 0.7); /* 배경을 반투명하게 설정 */
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-size: 14px;
+    z-index: 1; /* 이미지를 덮도록 설정 */
+}
+</style>

--- a/src/views/main/MainPage.vue
+++ b/src/views/main/MainPage.vue
@@ -46,9 +46,25 @@
         </div>
         <BestPackageSlide />
 
+        <br><br>
+        <div class="hr-style"></div>
+        <br>
     </v-container>
     <!-- 인기 패키지 끝 -->
 
+    <!-- 시청자 순 라이브 목록 -->
+    <v-container>
+        <v-col cols="12">
+            <div class="text-center slide-title" @click="this.$router.push('/live/list')">
+                📺 Live 📺
+                <v-icon icon="mdi-chevron-right" style="font-size: 46px;"/>
+            </div>
+            <p class="text-center" style="color: grey; font-size: 16px;">시청자가 가장 많은 라이브 목록입니다.</p>
+        </v-col>
+        <br>
+        <LiveListBest ref="liveListBest" :autoStart="false" />
+    </v-container>
+    <!-- 라이브 목록 끝  -->
 
     <v-dialog v-model="this.loginModal" max-width="300px">
         <v-card class="modal"
@@ -86,13 +102,15 @@
 <script>
 import BestFarmSlide from '@/components/slide/BestFarmSlide.vue';
 import BestPackageSlide from '@/components/slide/BestPackageSlide.vue';
+import LiveListBest from '../live/live/LiveListBest.vue';
 import axios from 'axios';
 import { aliases, mdi } from 'vuetify/iconsets/mdi'
 
 export default {
     components: {
         BestPackageSlide,
-        BestFarmSlide
+        BestFarmSlide,
+        LiveListBest,
     },
     icons: {
         defaultSet: 'mdi',
@@ -110,8 +128,15 @@ export default {
             farmList: [],
             farmOnboarding: 1,
             likes: [], // 0: 안눌려있는 상태, 1: 눌려있는 상태, 2: 눌리고 있는 상태(애니메이션처리)
-            likeCount: []
+            likeCount: [],
+            isLiveListInView: false,
         }
+    },
+    mounted() {
+        window.addEventListener('scroll', this.handleScroll);
+    },
+    beforeUnmount() {
+        window.removeEventListener('scroll', this.handleScroll);
     },
     methods: {
         saveScrollPosition() {
@@ -150,14 +175,36 @@ export default {
                 console.log(e);
 
             }
-        }
+        },
+        handleScroll() {
+            const liveListComponent = this.$refs.liveListBest;
+            if (liveListComponent && liveListComponent.$el) {
+                const rect = liveListComponent.$el.getBoundingClientRect();
+                const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+
+                if (rect.top <= windowHeight && rect.bottom >= 0) {
+                    // LiveListBest가 뷰포트 안에 있음
+                    if (!this.isLiveListInView) {
+                        this.isLiveListInView = true;
+                        liveListComponent.playPreviewAll();
+                    }
+                } else {
+                    // LiveListBest가 뷰포트 밖에 있음
+                    if (this.isLiveListInView) {
+                        this.isLiveListInView = false;
+                        liveListComponent.stopAllPreviews();
+                    }
+                }
+            }
+        },
     },
     async created() {
         // 테스트용 임시 데이터
         this.images = [
             // { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/mainpage/0dac11a7-7643-4fd0-a591-e6fb84ed7796inong1", "alt": "배너사진1", "link": "/event1" },
-            // { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/mainpage/7b389588-8eda-4eee-9502-703efca9d648inong2", "alt": "배너사진2", "link": "/event2" },
             { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/mainpage/a591fdfe-4151-4b7f-932a-d5afff886ae5banner2", "alt": "배너사진3", "link": "/event2" },
+            { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/mainpage/7b389588-8eda-4eee-9502-703efca9d648inong2", "alt": "배너사진2", "link": "/event2" },
+            // { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/mainpage/a591fdfe-4151-4b7f-932a-d5afff886ae5banner2", "alt": "배너사진3", "link": "/event2" },
             // { "src:": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/local/desktop+wallpaper.jpeg", "alt": "배너사진4", "link": "/event2" },
             // { "src": "https://dongsanginong-bucket.s3.ap-northeast-2.amazonaws.com/local/desktop+wallpaper.jpeg", "alt": "배너사진5", "link": "/event2" }
         ];

--- a/src/views/product/farm/FarmList.vue
+++ b/src/views/product/farm/FarmList.vue
@@ -5,9 +5,7 @@
             <v-card-title style="font-size: 20px; margin-bottom: 30px;"> <span style="font-weight: bold;">🏆 BEST 10 </span>
                 <span style="font-size: 15px; color: grey;"> 즐겨찾기 수가 많은 농장들입니다. </span>
             </v-card-title>
-            <!-- <div style="display: flex; justify-content: center; align-items:center;"> -->
                 <BestFarmMovingSlide />
-            <!-- </div> -->
         </v-card>
         <!-- top 10 끝 -->
 
@@ -36,41 +34,47 @@
             </v-row>
             <v-row>
                 <div v-for="(farm, index) in farmList" :key="index" class="farm-card-outer">
-
                     <div class="farm-info">
-                        <!-- 사진 영역 -->
-                        <div class="farm-image-frame">
-                            <v-img :src="farm.imageUrl" class="farm-image-circle"
-                            @click="this.$router.push(`/farm/${farm.id}/packages`)" cover />
-                        </div>
-                        <!-- 제목 영역 -->
-                        <div class="farm-description">
-                            <p style="font-size: 15px; font-weight: 600; font-size: 16px;">{{ farm.farmName }}</p>
-                        </div>
+                        <v-row>
+                            <v-col cols="1">
+                                <!-- 사진 영역 -->
+                                <div class="farm-image-frame">
+                                    <v-img :src="farm.imageUrl" class="farm-image-circle"
+                                    @click="this.$router.push(`/farm/${farm.id}/packages`)" cover />
+                                </div>
+                            </v-col>
 
-                        <!-- 즐겨찾기 영역 -->
-                        <div class="order-count-box">
-                            <v-chip class="order-count-chip" size="small">
-                                판매 {{ farm.orderCount }}개
-                            </v-chip>
-                        </div>
+                            <v-col style="justify-content: start;">
+                                <v-row>
+                                    <!-- 제목 영역 -->
+                                    <div class="farm-description">
+                                        <p style="font-size: 15px; font-weight: 600; font-size: 16px;">{{ farm.farmName }}</p>
+                                    </div>
+                                    <!-- 즐겨찾기 영역 -->
+                                    <div style="line-height: 70px; display: flex; justify-content: center; align-items: center;">
+                                        <div v-if="likes.get(farm.id) == 2" class="heart-emoji">
+                                            <svg-icon type="mdi" :path="mdiHeart" class="icon-colored"></svg-icon>
+                                        </div>
 
-                        <div style="line-height: 70px; display: flex; justify-content: center; align-items: center;">
-                            <div v-if="likes.get(farm.id) == 2" class="heart-emoji">
-                                <svg-icon type="mdi" :path="mdiHeart" class="icon-colored"></svg-icon>
-                            </div>
-
-                            <v-chip class="like-chip" size="small" variant="outlined"
-                                :class="{ 'selected-like-chip': likes.get(farm.id) == 1 || likes.get(farm.id) == 2 }"
-                                @click="clickLike(farm.id)">
-                                <svg-icon type="mdi"
-                                    :path="likes.get(farm.id) == 1 || likes.get(farm.id) == 2 ? mdiHeart : mdiHeartOutline"
-                                    :class="likes.get(farm.id) == 1 || likes.get(farm.id) == 2 ? 'icon-colored' : 'icon-trans'"></svg-icon>
-                                    <span style="font-weight: bold; font-size: 14px; padding-top: 2px">{{ likeCount.get(farm.id) }}</span>
-                            </v-chip>
-                        </div>
-
-                        
+                                        <v-chip class="like-chip" size="small" variant="outlined"
+                                            :class="{ 'selected-like-chip': likes.get(farm.id) == 1 || likes.get(farm.id) == 2 }"
+                                            @click="clickLike(farm.id)">
+                                            <svg-icon type="mdi"
+                                                :path="likes.get(farm.id) == 1 || likes.get(farm.id) == 2 ? mdiHeart : mdiHeartOutline"
+                                                :class="likes.get(farm.id) == 1 || likes.get(farm.id) == 2 ? 'icon-colored' : 'icon-trans'"></svg-icon>
+                                                <span style="font-weight: bold; font-size: 14px; padding-top: 2px">{{ likeCount.get(farm.id) }}</span>
+                                        </v-chip>
+                                    </div>
+                                </v-row>
+                                <v-row>
+                                    <div class="order-count-box">
+                                        <v-chip class="order-count-chip" size="small">
+                                            판매 {{ farm.orderCount }}개
+                                        </v-chip>
+                                    </div>
+                                </v-row>
+                            </v-col>
+                        </v-row>
                     </div>
 
                     <div class="package-info">
@@ -383,7 +387,8 @@ export default {
 .icon-colored {
     color: red;
     transform: scale(0.8);
-
+    width: 22px;
+    height: 22px;
 }
 
 .icon-trans {
@@ -501,7 +506,6 @@ export default {
 }
 
 .farm-description {
-    margin-left: 20px;
     line-height: 70px;
 }
 
@@ -571,8 +575,10 @@ export default {
 }
 
 .order-count-box {
-    line-height: 70px;
-    width: auto
+    width: auto;
+    margin-left: -1%;
+    margin-top: -2%;
+
 }
 
 .order-count-chip {
@@ -589,6 +595,7 @@ export default {
     border: 1px solid white !important;
     border-radius: 3px;
     color: black !important;
+    padding-bottom: 2px;
 }
 
 


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업
- [ ] 설정 변경


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
### 📍 메인 페이지에 live 목록 출력 

![live41](https://github.com/user-attachments/assets/f2ca3c91-ad93-4d10-83ef-a28dc6e372b7)
<br>

![image - 2024-10-20T020027 693](https://github.com/user-attachments/assets/273861a7-1675-4f9e-9c0a-829d71909dde)
스크롤을 내려 라이브 목록에 도달하면 => 세션 연결 
![image - 2024-10-20T020029 265](https://github.com/user-attachments/assets/eeb24143-a760-4a14-9440-b05d98619a30)
스크롤을 다시 올려 목록에서 벗어나면 => 세션 중지 (계속해서 세션이 연결되는 불필요한 부하를 방지) 

<br><br>

### 📍 시청순 best5
![스크린샷 2024-10-20 015019](https://github.com/user-attachments/assets/3c0d8621-e502-4574-8a63-d84f2990004c)
시청자가 많은 순으로 출력 => 이 부분은 라이브를 많이 진행시키고 그걸 또 많이 참여시키기가 어려워, 배포하고 다시 확인해봐야 할 것 같음 ! 

<br><br>

### 📍 farm list 디자인 수정 
![image - 2024-10-20T020331 139](https://github.com/user-attachments/assets/de98ec7f-71dc-4daf-99aa-e3dcdb827659)
한 줄로 출력되던 걸 두줄로 바꿈 

<br><br>
➕➕ 

![image](https://github.com/user-attachments/assets/a54140e4-ffef-438e-9be3-162b58da4a40)
프로필 이미지가 너무 큰 것 같아서 사이즈 작게 수정했습니다 ! 

## 📷 결과 화면
<!-- 화면을 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  closed #이슈변호  -->
closed #204 